### PR TITLE
fix python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8.1"
 streamlit = "*"
 altair = "<5"
 langchain = "*"


### PR DESCRIPTION
Fix the following dependence issue:

> The current project's Python requirement (>=3.7,<4.0) is not compatible with some of the required packages Python requirement:
>  - langchain-experimental requires Python >=3.8.1,<4.0, so it will not be satisfied for Python >=3.7,<3.8.1