### PR TITLE
fix: load .env from app, repo root, and plan paths

### DIFF
--- a/demogpt/app.py
+++ b/demogpt/app.py
@@ -2,6 +2,7 @@ import logging
 import os
 import signal
 import sys
+from pathlib import Path
 
 import streamlit as st
 import streamlit.components.v1 as components
@@ -15,12 +16,29 @@ sys.path.append(grandparent_directory)
 from model import DemoGPT
 from utils import runStreamlit
 
-try:
-    from dotenv import load_dotenv
 
-    load_dotenv()
-except Exception as e:
-    logging.error("dotenv import error but no needed")
+def load_environment_file() -> None:
+    """Load project .env files from the expected repository and app directories."""
+    try:
+        from dotenv import load_dotenv
+    except Exception:
+        logging.error("dotenv import error but no needed")
+        return
+
+    candidate_paths = [
+        Path(current_directory) / ".env",
+        Path(grandparent_directory) / ".env",
+        Path(current_directory) / "plan" / ".env",
+        Path(parent_directory) / "plan" / ".env",
+    ]
+
+    for path in candidate_paths:
+        if path.is_file():
+            load_dotenv(path)
+
+
+load_environment_file()
+
 
 
 def generate_response(txt):


### PR DESCRIPTION
## Summary
This patch makes `.env` loading deterministic across common DemoGPT layouts by loading from:

- `demogpt/.env`
- repository root `.env`
- `demogpt/plan/.env`
- `parent/plan/.env`

The previous implementation only invoked `load_dotenv()` without an explicit path, which depended on the working directory and contributed to issue reports where API keys were not picked up.

## Motivation
Issue: #42 `.env file seems not working`.

## Testing
- `python -m py_compile demogpt/app.py`
- targeted env-loader sanity check script to verify root `.env` is loaded via candidate paths
- `ruff check demogpt/app.py` (no new issues introduced beyond existing repo-level lint findings)
- `python -m unittest tests.test_llms tests.test_rag` (fails in current environment because `langchain_experimental` dependency is missing)

## Risks
- Existing environments that rely on other `.env` locations may be affected only if conflicting keys are defined.
- Behavior now relies on first-match loading semantics from a small set of candidate paths, so ambiguous multi-file setups may still need clarification in docs.

Closes #42
