### PR TITLE
feat: add LiteLLM as LLM provider

### DIFF
--- a/demogpt/chains/_llm_factory.py
+++ b/demogpt/chains/_llm_factory.py
@@ -1,0 +1,24 @@
+"""Shared factory for creating LLM instances in chain classes."""
+
+import os
+
+
+def create_llm(model, api_key=None, temperature=0.0, api_base=None, provider=None):
+    if provider == "litellm":
+        from demogpt_agenthub.llms.litellm import LiteLLMChatModel
+
+        kwargs = {"model": model, "temperature": temperature}
+        if api_key:
+            kwargs["api_key"] = api_key
+        if api_base:
+            kwargs["api_base"] = api_base
+        return LiteLLMChatModel(**kwargs)
+    else:
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            model=model,
+            openai_api_key=api_key or os.getenv("OPENAI_API_KEY", ""),
+            temperature=temperature,
+            openai_api_base=api_base,
+        )

--- a/demogpt/chains/chains.py
+++ b/demogpt/chains/chains.py
@@ -12,6 +12,7 @@ from langchain_core.output_parsers import StrOutputParser, JsonOutputParser
 
 from demogpt import utils
 from demogpt.chains.task_definitions import getPlanGenHelper, getTasks
+from demogpt.chains._llm_factory import create_llm
 from demogpt.controllers import validate
 
 from . import prompts
@@ -24,6 +25,7 @@ class Chains:
     openai_api_key = ""
     temperature = 0.0
     openai_api_base = None
+    provider = None
 
     @classmethod
     def setLlm(
@@ -32,38 +34,43 @@ class Chains:
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         temperature=0.0,
         openai_api_base=None,
-        has_gpt4=False
+        has_gpt4=False,
+        provider=None
     ):
         cls.openai_api_key=openai_api_key
         cls.temperature=temperature
         cls.openai_api_base=openai_api_base
         cls.has_gpt4=has_gpt4
-        cls.llm = ChatOpenAI(
+        cls.provider=provider
+        cls.llm = create_llm(
             model=model,
-            openai_api_key=openai_api_key,
+            api_key=openai_api_key,
             temperature=temperature,
-            openai_api_base=openai_api_base
+            api_base=openai_api_base,
+            provider=provider,
         )
         cls.model = model
-    
+
     @classmethod
     def getModel(cls, change=False, temperature=0, change_model="gpt-4o"):
         if change and cls.has_gpt4:
-            return ChatOpenAI(
+            return create_llm(
                 model=change_model,
-                openai_api_key=cls.openai_api_key,
+                api_key=cls.openai_api_key,
                 temperature=temperature,
-                openai_api_base=cls.openai_api_base
-        )
-        
+                api_base=cls.openai_api_base,
+                provider=cls.provider,
+            )
+
         if temperature > 0:
-            return ChatOpenAI(
+            return create_llm(
                 model=cls.model,
-                openai_api_key=cls.openai_api_key,
+                api_key=cls.openai_api_key,
                 temperature=temperature,
-                openai_api_base=cls.openai_api_base
-        )
-        
+                api_base=cls.openai_api_base,
+                provider=cls.provider,
+            )
+
         return cls.llm
         
     @classmethod

--- a/demogpt/chains/task_chains.py
+++ b/demogpt/chains/task_chains.py
@@ -11,6 +11,7 @@ from langchain_core.prompts.chat import (ChatPromptTemplate,
 
 from demogpt import utils
 from demogpt.chains import prompts
+from demogpt.chains._llm_factory import create_llm
 
 
 class TaskChains:
@@ -23,12 +24,14 @@ class TaskChains:
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         temperature=0.0,
         openai_api_base=None,
+        provider=None,
     ):
-        cls.llm = ChatOpenAI(
+        cls.llm = create_llm(
             model=model,
-            openai_api_key=openai_api_key,
+            api_key=openai_api_key,
             temperature=temperature,
-            openai_api_base=openai_api_base
+            api_base=openai_api_base,
+            provider=provider,
         )
 
     @classmethod

--- a/demogpt/chains/task_chains_seperate.py
+++ b/demogpt/chains/task_chains_seperate.py
@@ -12,6 +12,7 @@ from langchain_core.prompts.chat import (ChatPromptTemplate,
 
 from demogpt import utils
 from demogpt.chains import prompts
+from demogpt.chains._llm_factory import create_llm
 
 
 class TaskChainsSeperate:
@@ -24,12 +25,14 @@ class TaskChainsSeperate:
         openai_api_key=os.getenv("OPENAI_API_KEY", ""),
         temperature=0.0,
         openai_api_base=None,
+        provider=None,
     ):
-        cls.llm = ChatOpenAI(
+        cls.llm = create_llm(
             model=model,
-            openai_api_key=openai_api_key,
+            api_key=openai_api_key,
             temperature=temperature,
-            openai_api_base=openai_api_base
+            api_base=openai_api_base,
+            provider=provider,
         )
 
     @classmethod

--- a/demogpt/model.py
+++ b/demogpt/model.py
@@ -23,6 +23,7 @@ class DemoGPT:
         max_steps=10,
         plan_max_steps = 3,
         openai_api_base="",
+        provider=None,
     ):
         assert len(
             openai_api_key.strip()
@@ -32,6 +33,7 @@ class DemoGPT:
         self.max_steps = max_steps  # max iteration for refining the model purpose
         self.plan_max_steps = plan_max_steps # max iteration for refining the plan
         self.openai_api_base = openai_api_base
+        self.provider = provider
         self.FAIL_MESSAGE = """ğŸš€âœ¨ Impressive! While DemoGPT can handle a galaxy of app ideas, 
         you've shot for the stars with a unique one. We're ramping up our engines to meet such visionary requests. 
         Give us a little time, and we'll be right there with you.\n\nğŸ“§
@@ -64,13 +66,13 @@ We appreciate your understanding and look forward to seeing what you create! ğŸ˜
     def _initLlm(self):
         """Initialize LLM chains without model validation."""
         Chains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, has_gpt4=self.hasGPT4
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, has_gpt4=self.hasGPT4, provider=self.provider
         )
         TaskChains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, provider=self.provider
         )
         TaskChainsSeperate.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, provider=self.provider
         )
 
     @property
@@ -84,22 +86,13 @@ We appreciate your understanding and look forward to seeing what you create! ğŸ˜
         assert self.model_name in self.available_models , self.gpt4_message.format(model_name=self.model_name)
                 
         Chains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, has_gpt4=self.hasGPT4
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, has_gpt4=self.hasGPT4, provider=self.provider
         )
         TaskChains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, provider=self.provider
         )
         TaskChainsSeperate.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
-        )
-        Chains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, has_gpt4=self.hasGPT4
-        )
-        TaskChains.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
-        )
-        TaskChainsSeperate.setLlm(
-            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base
+            self.model_name, self.openai_api_key, openai_api_base=self.openai_api_base, provider=self.provider
         )
 
     def __repr__(self) -> str:

--- a/demogpt_agenthub/llms/__init__.py
+++ b/demogpt_agenthub/llms/__init__.py
@@ -1,1 +1,6 @@
 from demogpt_agenthub.llms.openai import OpenAIModel, OpenAIChatModel
+
+try:
+    from demogpt_agenthub.llms.litellm import LiteLLMChatModel
+except ImportError:
+    pass

--- a/demogpt_agenthub/llms/litellm.py
+++ b/demogpt_agenthub/llms/litellm.py
@@ -1,0 +1,70 @@
+from typing import Any, List, Optional
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from demogpt_agenthub.llms.base import BaseLLM
+
+
+class LiteLLMChatModel(BaseChatModel, BaseLLM):
+    """LLM provider that routes through the LiteLLM SDK.
+
+    Supports 100+ providers (Anthropic, Bedrock, Vertex, Azure, Groq, etc.)
+    using LiteLLM's unified model naming convention.
+    Provider API keys are read from environment variables.
+    """
+
+    model: str = "gpt-4o-mini"
+    api_key: Optional[str] = None
+    api_base: Optional[str] = None
+    temperature: float = 0.0
+
+    @property
+    def _llm_type(self) -> str:
+        return "litellm"
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        import litellm
+
+        message_dicts = [
+            {"role": _role_from_message(m), "content": m.content}
+            for m in messages
+        ]
+
+        params = {
+            "model": self.model,
+            "messages": message_dicts,
+            "temperature": self.temperature,
+            "drop_params": True,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        if self.api_base:
+            params["api_base"] = self.api_base
+        if stop:
+            params["stop"] = stop
+
+        response = litellm.completion(**params)
+        content = response.choices[0].message.content
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=content))])
+
+    def run(self, prompt: str) -> str:
+        return self.invoke(prompt).content
+
+
+def _role_from_message(msg: BaseMessage) -> str:
+    if msg.type == "human":
+        return "user"
+    elif msg.type == "ai":
+        return "assistant"
+    elif msg.type == "system":
+        return "system"
+    return "user"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ youtube-search = "*"
 stackapi = "*"
 wikipedia = "1.4.0"
 pyowm = "3.3.0"
+litellm = {version = ">=1.80.0,<1.87.0", optional = true}
+
+[tool.poetry.extras]
+litellm = ["litellm"]
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION


## Summary

- Add [LiteLLM](https://github.com/BerriAI/litellm) as a new LLM provider, giving DemoGPT users access to 100+ LLM providers (Anthropic, AWS Bedrock, Vertex AI, Azure, Groq, Cohere, Mistral, Together, Fireworks, etc.) through the LiteLLM Python SDK
- Works in both the agenthub layer (`LiteLLMChatModel` for agents/RAG) and the chains layer (via `create_llm()` factory)
- Activated by passing `provider="litellm"` to `DemoGPT()` or using `LiteLLMChatModel` directly

## Changes

- `demogpt_agenthub/llms/litellm.py` -- new `LiteLLMChatModel` extending both `BaseChatModel` (LangChain runnable) and `BaseLLM`, calls `litellm.completion()` with `drop_params=True`
- `demogpt_agenthub/llms/__init__.py` -- export `LiteLLMChatModel` (lazy import, no breakage if litellm not installed)
- `demogpt/chains/_llm_factory.py` -- shared factory that creates `LiteLLMChatModel` when `provider="litellm"`, `ChatOpenAI` otherwise
- `demogpt/chains/chains.py` -- `Chains.setLlm()` and `Chains.getModel()` use factory, accept `provider` param
- `demogpt/chains/task_chains.py` -- `TaskChains.setLlm()` uses factory, accepts `provider` param
- `demogpt/chains/task_chains_seperate.py` -- same
- `demogpt/model.py` -- `DemoGPT.__init__()` accepts `provider` param, passes through to all chain classes
- `pyproject.toml` -- add `litellm>=1.80.0,<1.87.0` as optional dependency (`pip install demogpt[litellm]`)

## Tests

**1. Live E2E: LiteLLMChatModel.run() (Azure Foundry -> Claude Sonnet 4.6)**

```python
from demogpt_agenthub.llms.litellm import LiteLLMChatModel

model = LiteLLMChatModel(model='azure_ai/claude-sonnet-4-6')
result = model.run('What is 2+2? Reply with just the number.')
```

```
Response: 4
Type: str
```

**2. Live E2E: LangChain pipe compatibility (used by agents)**

```python
chain = ChatPromptTemplate.from_template('Reply with just: {word}') | model | StrOutputParser()
pipe_result = chain.invoke({'word': 'pong'})
```

```
Pipe result: pong
```

**3. Live E2E: Chains factory path**

```python
from demogpt.chains._llm_factory import create_llm

llm = create_llm(model='azure_ai/claude-sonnet-4-6', provider='litellm')
result = llm.invoke('Reply with just: pong')
```

```
Factory result: pong
Type: LiteLLMChatModel
```

## Example usage

**Agenthub (agents, RAG):**

```python
from demogpt_agenthub.llms.litellm import LiteLLMChatModel
from demogpt_agenthub.agents import ToolCallingAgent

# Provider API keys read from env: export ANTHROPIC_API_KEY=sk-ant-...
llm = LiteLLMChatModel(model="anthropic/claude-sonnet-4-20250514")
agent = ToolCallingAgent(tools=[...], llm=llm)
result = agent.run("What is the weather in Paris?")
```

**Main DemoGPT app:**

```python
from demogpt.model import DemoGPT

# Provider API keys read from env: export ANTHROPIC_API_KEY=sk-ant-...
demo = DemoGPT(
    model_name="anthropic/claude-sonnet-4-20250514",
    provider="litellm",
)
```

Supported model formats (LiteLLM convention):

- `anthropic/claude-sonnet-4-20250514` -- Anthropic
- `bedrock/anthropic.claude-sonnet-4-20250514-v1:0` -- AWS Bedrock
- `vertex_ai/gemini-2.5-flash` -- Google Vertex
- `azure_ai/claude-sonnet-4-6` -- Azure AI Foundry
- `groq/llama-3.3-70b-versatile` -- Groq
- `ollama/llama3` -- Local Ollama

## Risk / Compatibility

- Additive only -- no existing providers modified
- `LiteLLMChatModel` follows the exact same dual-inheritance pattern as `OpenAIChatModel(ChatOpenAI, BaseLLM)`, just swapping the LangChain base for a custom `BaseChatModel` that calls litellm SDK
- `provider` parameter defaults to `None`, preserving existing OpenAI behavior
- `litellm` is an optional dependency -- existing users without it are unaffected (lazy import with try/except)
- `drop_params=True` ensures unsupported params are silently dropped per provider
